### PR TITLE
Use atty-only editor launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,10 +78,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bstr"
@@ -93,6 +110,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -153,6 +176,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "edit"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f364860e764787163c8c8f58231003839be31276e821e2ad2092ddf496b1aa09"
+dependencies = [
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,16 +215,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "extract"
 version = "0.0.1"
 dependencies = [
  "assert_cmd",
+ "atty",
  "clap",
+ "edit",
  "env_logger",
  "log",
  "predicates",
  "regex",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "float-cmp"
@@ -197,10 +254,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -239,6 +326,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +363,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -335,6 +440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +473,32 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys",
+]
 
 [[package]]
 name = "serde"
@@ -401,6 +538,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +576,49 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -499,3 +692,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ clap = { version = "4.4", features = ["derive"] }
 regex = "1"
 log = "0.4"
 env_logger = "0.11.8"
+edit = "0.1.5"
+atty = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ Output:
 
 ### Interactive Mode
 
-Run without arguments to enter interactive mode:
+Run without arguments to launch your `$EDITOR` for interactive input. If no editor is found, you'll be prompted to type the text directly:
 
 ```bash
 extract
 ```
 
-Type your text and end with `EOF` or Ctrl-D.
+Enter your text in the editor and save. If using the stdin fallback, end the input with Ctrl-D when finished.
 
 ### Command Options
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
+use atty::Stream;
 use clap::{Parser, Subcommand};
+use edit;
 use log::{debug, LevelFilter};
 use regex::Regex;
-use std::io::{self, BufRead};
+use std::io::{self, Read, ErrorKind};
 use std::net::IpAddr;
 use std::sync::LazyLock;
 
@@ -10,14 +12,12 @@ use std::sync::LazyLock;
 const MAX_INT_IN_V6: u32 = 9999;
 
 /// Regex pattern for splitting text on common IP address delimiters
-static DELIMITERS: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"[,\s|$>=]").expect("Invalid delimiter regex")
-});
+static DELIMITERS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[,\s|$>=]").expect("Invalid delimiter regex"));
 
 /// Regex pattern for detecting potential port numbers at the end of strings
-static MAYBE_PORT: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r":\d{1,6}$").expect("Invalid port regex")
-});
+static MAYBE_PORT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r":\d{1,6}$").expect("Invalid port regex"));
 
 #[derive(Subcommand)]
 enum Commands {
@@ -26,7 +26,11 @@ enum Commands {
 }
 
 #[derive(Parser)]
-#[command(name = "extract", version, about = "Extract network identifiers from text")]
+#[command(
+    name = "extract",
+    version,
+    about = "Extract network identifiers from text"
+)]
 struct Cli {
     /// Enable debug logging.
     #[arg(long)]
@@ -45,7 +49,7 @@ fn is_an_ip(ip: &str) -> bool {
 fn strip_quotes(s: &str) -> &str {
     if s.len() >= 2 {
         if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
-            return &s[1..s.len()-1];
+            return &s[1..s.len() - 1];
         }
     }
     s
@@ -54,7 +58,7 @@ fn strip_quotes(s: &str) -> &str {
 /// Removes brackets from IPv6 addresses if present
 fn strip_brackets(s: &str) -> &str {
     if s.len() >= 2 && s.starts_with('[') && s.ends_with(']') {
-        &s[1..s.len()-1]
+        &s[1..s.len() - 1]
     } else {
         s
     }
@@ -68,12 +72,12 @@ fn remove_port_if_present(s: &str) -> Option<String> {
             return Some(s[1..bracket_end].to_string());
         }
     }
-    
+
     // Handle cases with dots or brackets and potential ports
     if (s.contains('.') || s.contains(']')) && MAYBE_PORT.is_match(s) {
         let parts: Vec<&str> = s.split(':').collect();
         if parts.len() > 1 {
-            return Some(parts[..parts.len()-1].join(":"));
+            return Some(parts[..parts.len() - 1].join(":"));
         }
     }
 
@@ -83,19 +87,19 @@ fn remove_port_if_present(s: &str) -> Option<String> {
             if let Ok(num) = last.parse::<u32>() {
                 if num > MAX_INT_IN_V6 {
                     let parts: Vec<&str> = s.split(':').collect();
-                    return Some(parts[..parts.len()-1].join(":"));
+                    return Some(parts[..parts.len() - 1].join(":"));
                 }
             }
         }
     }
-    
+
     None
 }
 
 /// Extracts IP addresses from a text string
 fn ip_finder(s: &str) -> Vec<String> {
     let mut elements = Vec::new();
-    
+
     for chunk in DELIMITERS.split(s) {
         if chunk.is_empty() {
             continue;
@@ -103,19 +107,19 @@ fn ip_finder(s: &str) -> Vec<String> {
 
         // Process the chunk through various transformations
         let mut processed = chunk;
-        
+
         // Remove quotes
         processed = strip_quotes(processed);
-        
+
         // Try to remove port if present, otherwise use original
         let without_port = remove_port_if_present(processed);
         if let Some(ref port_removed) = without_port {
             processed = port_removed;
         }
-        
+
         // Remove brackets for IPv6
         processed = strip_brackets(processed);
-        
+
         if processed.is_empty() {
             continue;
         }
@@ -159,23 +163,23 @@ fn ip_finder(s: &str) -> Vec<String> {
 /// Extracts CIDR notation (IP/prefix) from text
 fn cidr_finder(s: &str) -> Vec<String> {
     let mut elements = Vec::new();
-    
+
     for chunk in DELIMITERS.split(s) {
         if chunk.is_empty() || !chunk.contains('/') {
             continue;
         }
 
         let processed = strip_quotes(chunk);
-        
+
         if let Some(slash_pos) = processed.find('/') {
             let ip_part = &processed[..slash_pos];
             let prefix_part = &processed[slash_pos + 1..];
-            
+
             if let Ok(prefix) = prefix_part.parse::<u8>() {
                 if is_an_ip(ip_part) {
                     let is_ipv4 = ip_part.contains('.');
                     let max_prefix = if is_ipv4 { 32 } else { 128 };
-                    
+
                     if prefix <= max_prefix {
                         elements.push(processed.to_string());
                     }
@@ -183,78 +187,90 @@ fn cidr_finder(s: &str) -> Vec<String> {
             }
         }
     }
-    
+
     elements
 }
 
 /// Extracts MAC addresses from text (supports colon and dash formats)
 fn mac_finder(s: &str) -> Vec<String> {
     let mut elements = Vec::new();
-    
+
     for chunk in DELIMITERS.split(s) {
         if chunk.is_empty() {
             continue;
         }
 
         let processed = strip_quotes(chunk);
-        
+
         // Check for colon format (xx:xx:xx:xx:xx:xx)
         if processed.matches(':').count() == 5 {
             let parts: Vec<&str> = processed.split(':').collect();
-            if parts.len() == 6 && parts.iter().all(|part| part.len() == 2 && part.chars().all(|c| c.is_ascii_hexdigit())) {
+            if parts.len() == 6
+                && parts
+                    .iter()
+                    .all(|part| part.len() == 2 && part.chars().all(|c| c.is_ascii_hexdigit()))
+            {
                 elements.push(processed.to_string());
                 continue;
             }
         }
-        
+
         // Check for dash format (xx-xx-xx-xx-xx-xx)
         if processed.matches('-').count() == 5 {
             let parts: Vec<&str> = processed.split('-').collect();
-            if parts.len() == 6 && parts.iter().all(|part| part.len() == 2 && part.chars().all(|c| c.is_ascii_hexdigit())) {
+            if parts.len() == 6
+                && parts
+                    .iter()
+                    .all(|part| part.len() == 2 && part.chars().all(|c| c.is_ascii_hexdigit()))
+            {
                 elements.push(processed.to_string());
                 continue;
             }
         }
-        
+
         // Check for Cisco format (xxxx.xxxx.xxxx)
         if processed.matches('.').count() == 2 {
             let parts: Vec<&str> = processed.split('.').collect();
-            if parts.len() == 3 && parts.iter().all(|part| part.len() == 4 && part.chars().all(|c| c.is_ascii_hexdigit())) {
+            if parts.len() == 3
+                && parts
+                    .iter()
+                    .all(|part| part.len() == 4 && part.chars().all(|c| c.is_ascii_hexdigit()))
+            {
                 elements.push(processed.to_string());
             }
         }
     }
-    
+
     elements
 }
 
 /// Extracts IP ranges from text (IP-IP format)
 fn range_finder(s: &str) -> Vec<String> {
     let mut elements = Vec::new();
-    
+
     for chunk in DELIMITERS.split(s) {
         if chunk.is_empty() || !chunk.contains('-') {
             continue;
         }
 
         let processed = strip_quotes(chunk);
-        
+
         if let Some(dash_pos) = processed.find('-') {
             let start_ip = &processed[..dash_pos];
             let end_ip = &processed[dash_pos + 1..];
-            
+
             if is_an_ip(start_ip) && is_an_ip(end_ip) {
                 // Ensure both IPs are same type
                 let start_is_ipv4 = start_ip.contains('.');
                 let end_is_ipv4 = end_ip.contains('.');
-                
+
                 if start_is_ipv4 == end_is_ipv4 {
                     elements.push(processed.to_string());
                 }
             }
         }
     }
-    
+
     elements
 }
 
@@ -276,41 +292,54 @@ fn main() {
         return;
     }
 
-    eprintln!("Input text. End input with Ctrl-d or EOF on a new line.");
+    let mut input = String::new();
 
-    let stdin = io::stdin();
-    let mut lines = Vec::new();
-    for line in stdin.lock().lines() {
-        match line {
-            Ok(l) => {
-                if l == "EOF" {
-                    break;
-                }
-                lines.push(l);
-            }
+    if atty::is(Stream::Stdin) {
+        eprintln!("Opening $EDITOR for input. Save and quit to continue.");
+        match edit::edit("") {
+            Ok(text) => input = text,
             Err(e) => {
-                eprintln!("Error reading input: {}", e);
-                break;
+                if e.kind() == ErrorKind::NotFound {
+                    eprintln!("No editor found. Falling back to stdin. End input with Ctrl-D.");
+                    if let Err(err) = io::stdin().read_to_string(&mut input) {
+                        eprintln!("Error reading input: {}", err);
+                        return;
+                    }
+                } else {
+                    eprintln!("Error launching editor: {}", e);
+                    return;
+                }
             }
         }
+    } else {
+        let stdin = io::stdin();
+        if let Err(e) = stdin.lock().read_to_string(&mut input) {
+            eprintln!("Error reading input: {}", e);
+            return;
+        }
+    }
+
+    let mut lines = Vec::new();
+    for line in input.lines() {
+        lines.push(line.to_string());
     }
 
     let mut all_tokens = Vec::new();
     for line in lines {
         debug!("Processing line: {}", line);
-        
+
         let ips = ip_finder(&line);
         debug!("Found IPs: {:?}", ips);
         all_tokens.extend(ips);
-        
+
         let cidrs = cidr_finder(&line);
         debug!("Found CIDRs: {:?}", cidrs);
         all_tokens.extend(cidrs);
-        
+
         let macs = mac_finder(&line);
         debug!("Found MACs: {:?}", macs);
         all_tokens.extend(macs);
-        
+
         let ranges = range_finder(&line);
         debug!("Found ranges: {:?}", ranges);
         all_tokens.extend(ranges);
@@ -333,10 +362,7 @@ mod tests {
     #[test]
     fn test_version_subcommand() {
         let mut cmd = Command::cargo_bin("extract").unwrap();
-        cmd.arg("version")
-            .assert()
-            .success()
-            .stdout("0.0.1\n");
+        cmd.arg("version").assert().success().stdout("0.0.1\n");
     }
 
     #[test]
@@ -352,16 +378,16 @@ mod tests {
     fn test_main_debug_flag() {
         let mut cmd = Command::cargo_bin("extract").unwrap();
         cmd.arg("--debug")
-            .write_stdin("EOF\n")
+            .write_stdin("1.2.3.4\n")
             .assert()
             .success()
-            .stderr(predicate::str::contains("Input text. End input with Ctrl-d or EOF on a new line."));
+            .stderr(predicate::str::contains("Processing line: 1.2.3.4"));
     }
 
     #[test]
     fn test_main_prints_extracted_ips() {
         let mut cmd = Command::cargo_bin("extract").unwrap();
-        cmd.write_stdin("1.2.3.4 5.6.7.8\nEOF\n")
+        cmd.write_stdin("1.2.3.4 5.6.7.8\n")
             .assert()
             .success()
             .stdout("1.2.3.4\n5.6.7.8\n");
@@ -370,7 +396,7 @@ mod tests {
     #[test]
     fn test_main_extracts_all_network_tokens() {
         let mut cmd = Command::cargo_bin("extract").unwrap();
-        cmd.write_stdin("IP: 192.168.1.1, CIDR: 10.0.0.0/8, MAC: 00:11:22:33:44:55, Range: 172.16.1.1-172.16.1.10\nEOF\n")
+        cmd.write_stdin("IP: 192.168.1.1, CIDR: 10.0.0.0/8, MAC: 00:11:22:33:44:55, Range: 172.16.1.1-172.16.1.10\n")
             .assert()
             .success()
             .stdout("192.168.1.1\n10.0.0.0/8\n00:11:22:33:44:55\n172.16.1.1-172.16.1.10\n");
@@ -404,51 +430,84 @@ mod tests {
 
     #[test]
     fn test_ip_finder_src_dst() {
-        assert_eq!(ip_finder("src:1.1.1.1,dst:2.2.2.2"), vec!["1.1.1.1", "2.2.2.2"]);
-        assert_eq!(ip_finder("src:1.1.1.1, dst:2.2.2.2"), vec!["1.1.1.1", "2.2.2.2"]);
-        assert_eq!(ip_finder(&format!("src:{}, dst:{}", EXAMPLE_V6_1, EXAMPLE_V6_2)), vec![EXAMPLE_V6_1, EXAMPLE_V6_2]);
+        assert_eq!(
+            ip_finder("src:1.1.1.1,dst:2.2.2.2"),
+            vec!["1.1.1.1", "2.2.2.2"]
+        );
+        assert_eq!(
+            ip_finder("src:1.1.1.1, dst:2.2.2.2"),
+            vec!["1.1.1.1", "2.2.2.2"]
+        );
+        assert_eq!(
+            ip_finder(&format!("src:{}, dst:{}", EXAMPLE_V6_1, EXAMPLE_V6_2)),
+            vec![EXAMPLE_V6_1, EXAMPLE_V6_2]
+        );
     }
 
     #[test]
     fn test_ip_finder_mixed_delimiters() {
-        assert_eq!(ip_finder("1.1.1.1 2.2.2.2,3.3.3.3"), vec!["1.1.1.1", "2.2.2.2", "3.3.3.3"]);
-        assert_eq!(ip_finder("1.1.1.1 2.2.2.2, 3.3.3.3"), vec!["1.1.1.1", "2.2.2.2", "3.3.3.3"]);
-        assert_eq!(ip_finder(&format!("{}, {}", EXAMPLE_V6_1, EXAMPLE_V6_2)), vec![EXAMPLE_V6_1, EXAMPLE_V6_2]);
+        assert_eq!(
+            ip_finder("1.1.1.1 2.2.2.2,3.3.3.3"),
+            vec!["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+        );
+        assert_eq!(
+            ip_finder("1.1.1.1 2.2.2.2, 3.3.3.3"),
+            vec!["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+        );
+        assert_eq!(
+            ip_finder(&format!("{}, {}", EXAMPLE_V6_1, EXAMPLE_V6_2)),
+            vec![EXAMPLE_V6_1, EXAMPLE_V6_2]
+        );
     }
 
     #[test]
     fn test_ip_finder_space_delimiter() {
         assert_eq!(ip_finder("1.1.1.1 "), vec!["1.1.1.1"]);
         assert_eq!(ip_finder("1.1.1.1 2.2.2.2"), vec!["1.1.1.1", "2.2.2.2"]);
-        assert_eq!(ip_finder(&format!("{} {}", EXAMPLE_V6_1, EXAMPLE_V6_2)), vec![EXAMPLE_V6_1, EXAMPLE_V6_2]);
+        assert_eq!(
+            ip_finder(&format!("{} {}", EXAMPLE_V6_1, EXAMPLE_V6_2)),
+            vec![EXAMPLE_V6_1, EXAMPLE_V6_2]
+        );
     }
 
     #[test]
     fn test_ip_finder_comma_delimiter() {
         assert_eq!(ip_finder("1.1.1.1,"), vec!["1.1.1.1"]);
         assert_eq!(ip_finder("1.1.1.1,2.2.2.2"), vec!["1.1.1.1", "2.2.2.2"]);
-        assert_eq!(ip_finder(&format!("{},{}", EXAMPLE_V6_1, EXAMPLE_V6_2)), vec![EXAMPLE_V6_1, EXAMPLE_V6_2]);
+        assert_eq!(
+            ip_finder(&format!("{},{}", EXAMPLE_V6_1, EXAMPLE_V6_2)),
+            vec![EXAMPLE_V6_1, EXAMPLE_V6_2]
+        );
     }
 
     #[test]
     fn test_ip_finder_pipe_delimiter() {
         assert_eq!(ip_finder("1.1.1.1|"), vec!["1.1.1.1"]);
         assert_eq!(ip_finder("1.1.1.1|2.2.2.2"), vec!["1.1.1.1", "2.2.2.2"]);
-        assert_eq!(ip_finder(&format!("{}|{}", EXAMPLE_V6_1, EXAMPLE_V6_2)), vec![EXAMPLE_V6_1, EXAMPLE_V6_2]);
+        assert_eq!(
+            ip_finder(&format!("{}|{}", EXAMPLE_V6_1, EXAMPLE_V6_2)),
+            vec![EXAMPLE_V6_1, EXAMPLE_V6_2]
+        );
     }
 
     #[test]
     fn test_ip_finder_tab_delimiter() {
         assert_eq!(ip_finder("1.1.1.1\t"), vec!["1.1.1.1"]);
         assert_eq!(ip_finder("1.1.1.1\t2.2.2.2"), vec!["1.1.1.1", "2.2.2.2"]);
-        assert_eq!(ip_finder(&format!("{}\t{}", EXAMPLE_V6_1, EXAMPLE_V6_2)), vec![EXAMPLE_V6_1, EXAMPLE_V6_2]);
+        assert_eq!(
+            ip_finder(&format!("{}\t{}", EXAMPLE_V6_1, EXAMPLE_V6_2)),
+            vec![EXAMPLE_V6_1, EXAMPLE_V6_2]
+        );
     }
 
     #[test]
     fn test_ip_finder_newline_delimiter() {
         assert_eq!(ip_finder("1.1.1.1\n"), vec!["1.1.1.1"]);
         assert_eq!(ip_finder("1.1.1.1\n2.2.2.2"), vec!["1.1.1.1", "2.2.2.2"]);
-        assert_eq!(ip_finder(&format!("{}\n{}", EXAMPLE_V6_1, EXAMPLE_V6_2)), vec![EXAMPLE_V6_1, EXAMPLE_V6_2]);
+        assert_eq!(
+            ip_finder(&format!("{}\n{}", EXAMPLE_V6_1, EXAMPLE_V6_2)),
+            vec![EXAMPLE_V6_1, EXAMPLE_V6_2]
+        );
         assert_eq!(ip_finder("1.1.1.1\r\n"), vec!["1.1.1.1"]);
         assert_eq!(ip_finder("1.1.1.1\r\n2.2.2.2"), vec!["1.1.1.1", "2.2.2.2"]);
     }
@@ -456,30 +515,51 @@ mod tests {
     #[test]
     fn test_ip_finder_quoted() {
         assert_eq!(ip_finder("\"1.1.1.1\","), vec!["1.1.1.1"]);
-        assert_eq!(ip_finder("\"1.1.1.1\",\n\"2.2.2.2\""), vec!["1.1.1.1", "2.2.2.2"]);
+        assert_eq!(
+            ip_finder("\"1.1.1.1\",\n\"2.2.2.2\""),
+            vec!["1.1.1.1", "2.2.2.2"]
+        );
         assert_eq!(ip_finder("'1.1.1.1',"), vec!["1.1.1.1"]);
-        assert_eq!(ip_finder("'1.1.1.1',\n'2.2.2.2'"), vec!["1.1.1.1", "2.2.2.2"]);
+        assert_eq!(
+            ip_finder("'1.1.1.1',\n'2.2.2.2'"),
+            vec!["1.1.1.1", "2.2.2.2"]
+        );
     }
 
     #[test]
     fn test_ip_finder_with_ports() {
         assert_eq!(ip_finder("1.1.1.1:65000"), vec!["1.1.1.1"]);
-        assert_eq!(ip_finder("1.1.1.1:65000,2.2.2.2:443"), vec!["1.1.1.1", "2.2.2.2"]);
+        assert_eq!(
+            ip_finder("1.1.1.1:65000,2.2.2.2:443"),
+            vec!["1.1.1.1", "2.2.2.2"]
+        );
         assert_eq!(ip_finder("1.2.3.4:abcd"), vec!["1.2.3.4"]);
         assert_eq!(ip_finder("foo:.:2.2.2.2"), Vec::<String>::new());
         assert_eq!(ip_finder("[1.1.1.1]:65000"), vec!["1.1.1.1"]);
-        assert_eq!(ip_finder("[1.1.1.1]:65000,[2.2.2.2]:443"), vec!["1.1.1.1", "2.2.2.2"]);
+        assert_eq!(
+            ip_finder("[1.1.1.1]:65000,[2.2.2.2]:443"),
+            vec!["1.1.1.1", "2.2.2.2"]
+        );
     }
 
     #[test]
     fn test_ip_finder_ipv6_with_ports() {
-        assert_eq!(ip_finder(&format!("{}:65000", EXAMPLE_V6_1)), vec![EXAMPLE_V6_1]);
+        assert_eq!(
+            ip_finder(&format!("{}:65000", EXAMPLE_V6_1)),
+            vec![EXAMPLE_V6_1]
+        );
         let input = format!("{}:65000, {}:80", EXAMPLE_V6_1, EXAMPLE_V6_2);
         let result = ip_finder(&input);
         assert!(result.contains(&EXAMPLE_V6_1.to_string()));
-        
-        assert_eq!(ip_finder(&format!("[{}]:65000", EXAMPLE_V6_1)), vec![EXAMPLE_V6_1]);
-        assert_eq!(ip_finder(&format!("[{}]:65000, [{}]:80", EXAMPLE_V6_1, EXAMPLE_V6_2)), vec![EXAMPLE_V6_1, EXAMPLE_V6_2]);
+
+        assert_eq!(
+            ip_finder(&format!("[{}]:65000", EXAMPLE_V6_1)),
+            vec![EXAMPLE_V6_1]
+        );
+        assert_eq!(
+            ip_finder(&format!("[{}]:65000, [{}]:80", EXAMPLE_V6_1, EXAMPLE_V6_2)),
+            vec![EXAMPLE_V6_1, EXAMPLE_V6_2]
+        );
     }
 
     #[test]
@@ -488,7 +568,14 @@ mod tests {
             "The IP 1.1.1.1 is having trouble talking to\n    2.2.2.2 on port 5555.\n\n    Others:\n    src:1.1.1.2 -> dst:2.2.2.3:771\n    src:{} -> dst: [{}]:443\n    any issue?",
             EXAMPLE_V6_1, EXAMPLE_V6_2
         );
-        let expected = vec!["1.1.1.1", "2.2.2.2", "1.1.1.2", "2.2.2.3", EXAMPLE_V6_1, EXAMPLE_V6_2];
+        let expected = vec![
+            "1.1.1.1",
+            "2.2.2.2",
+            "1.1.1.2",
+            "2.2.2.3",
+            EXAMPLE_V6_1,
+            EXAMPLE_V6_2,
+        ];
         assert_eq!(ip_finder(&input), expected);
     }
 
@@ -535,7 +622,10 @@ mod tests {
     fn test_cidr_finder_edge_cases() {
         let input = "0.0.0.0/0 127.0.0.1/32 ::/0 2001:db8::/128";
         let result = cidr_finder(&input);
-        assert_eq!(result, vec!["0.0.0.0/0", "127.0.0.1/32", "::/0", "2001:db8::/128"]);
+        assert_eq!(
+            result,
+            vec!["0.0.0.0/0", "127.0.0.1/32", "::/0", "2001:db8::/128"]
+        );
     }
 
     // Tests for MAC address extraction
@@ -585,7 +675,10 @@ mod tests {
     fn test_mac_finder_cisco_mixed() {
         let input = "00:11:22:33:44:55 0011.2233.4466 00-11-22-33-44-77";
         let result = mac_finder(&input);
-        assert_eq!(result, vec!["00:11:22:33:44:55", "0011.2233.4466", "00-11-22-33-44-77"]);
+        assert_eq!(
+            result,
+            vec!["00:11:22:33:44:55", "0011.2233.4466", "00-11-22-33-44-77"]
+        );
     }
 
     #[test]
@@ -600,7 +693,10 @@ mod tests {
     fn test_range_finder_ipv4() {
         let input = "192.168.1.1-192.168.1.10 10.0.0.1-10.0.0.5";
         let result = range_finder(&input);
-        assert_eq!(result, vec!["192.168.1.1-192.168.1.10", "10.0.0.1-10.0.0.5"]);
+        assert_eq!(
+            result,
+            vec!["192.168.1.1-192.168.1.10", "10.0.0.1-10.0.0.5"]
+        );
     }
 
     #[test]
@@ -681,23 +777,31 @@ Email: john.doe@company.com"#;
 
         // Expected results based on actual extraction capabilities
         let expected_ips = vec![
-            "192.168.10.5", "10.0.1.100", "192.168.1.50", "10.8.0.1", "10.8.0.50", 
-            "2001:db8::1", "2001:db8::2", "203.0.113.100", "198.51.100.5", 
-            "192.168.1.1", "192.168.1.1", "192.168.1.1"  // Multiple port scans on same IP
+            "192.168.10.5",
+            "10.0.1.100",
+            "192.168.1.50",
+            "10.8.0.1",
+            "10.8.0.50",
+            "2001:db8::1",
+            "2001:db8::2",
+            "203.0.113.100",
+            "198.51.100.5",
+            "192.168.1.1",
+            "192.168.1.1",
+            "192.168.1.1", // Multiple port scans on same IP
         ];
 
         let expected_cidrs = vec![
-            "172.16.0.0/24", "2001:db8::/32", "169.254.1.100/16", "10.10.10.0/28"
+            "172.16.0.0/24",
+            "2001:db8::/32",
+            "169.254.1.100/16",
+            "10.10.10.0/28",
         ];
 
         // Note: Some MACs not extracted due to format/context limitations
-        let expected_macs = vec![
-            "aa-bb-cc-dd-ee-ff", "00-DE-AD-BE-EF-00", "DEAD.BEEF.CAFE"
-        ];
+        let expected_macs = vec!["aa-bb-cc-dd-ee-ff", "00-DE-AD-BE-EF-00", "DEAD.BEEF.CAFE"];
 
-        let expected_ranges = vec![
-            "10.0.0.1-10.0.0.254", "172.31.1.1-172.31.1.100"
-        ];
+        let expected_ranges = vec!["10.0.0.1-10.0.0.254", "172.31.1.1-172.31.1.100"];
 
         assert_eq!(all_ips, expected_ips);
         assert_eq!(all_cidrs, expected_cidrs);
@@ -717,7 +821,10 @@ Email: john.doe@company.com"#;
     fn test_ip_finder_ipv6_compressed() {
         let input = "2001:db8:85a3::8a2e:370:7334 2001:db8::1 ::1 ::";
         let result = ip_finder(&input);
-        assert_eq!(result, vec!["2001:db8:85a3::8a2e:370:7334", "2001:db8::1", "::1", "::"]);
+        assert_eq!(
+            result,
+            vec!["2001:db8:85a3::8a2e:370:7334", "2001:db8::1", "::1", "::"]
+        );
     }
 
     #[test]
@@ -731,7 +838,14 @@ Email: john.doe@company.com"#;
     fn test_ip_finder_ipv6_mapped_ipv4() {
         let input = "::ffff:192.168.1.1 ::ffff:c0a8:101 64:ff9b::192.0.2.33";
         let result = ip_finder(&input);
-        assert_eq!(result, vec!["::ffff:192.168.1.1", "::ffff:c0a8:101", "64:ff9b::192.0.2.33"]);
+        assert_eq!(
+            result,
+            vec![
+                "::ffff:192.168.1.1",
+                "::ffff:c0a8:101",
+                "64:ff9b::192.0.2.33"
+            ]
+        );
     }
 
     #[test]
@@ -777,14 +891,23 @@ Email: john.doe@company.com"#;
     fn test_ip_finder_ipv6_mixed_case() {
         let input = "2001:DB8::1 2001:db8:85A3::8a2E:370:7334 FE80::1";
         let result = ip_finder(&input);
-        assert_eq!(result, vec!["2001:DB8::1", "2001:db8:85A3::8a2E:370:7334", "FE80::1"]);
+        assert_eq!(
+            result,
+            vec!["2001:DB8::1", "2001:db8:85A3::8a2E:370:7334", "FE80::1"]
+        );
     }
 
     #[test]
     fn test_ip_finder_ipv6_edge_cases() {
         let input = "2001:db8:0:0:1:0:0:1 2001:0db8:0000:0042:0000:8329:0000:0000";
         let result = ip_finder(&input);
-        assert_eq!(result, vec!["2001:db8:0:0:1:0:0:1", "2001:0db8:0000:0042:0000:8329:0000:0000"]);
+        assert_eq!(
+            result,
+            vec![
+                "2001:db8:0:0:1:0:0:1",
+                "2001:0db8:0000:0042:0000:8329:0000:0000"
+            ]
+        );
     }
 
     #[test]
@@ -799,7 +922,16 @@ Email: john.doe@company.com"#;
     fn test_cidr_finder_ipv6_comprehensive() {
         let input = "2001:db8::/32 fe80::/10 ::1/128 ::/0 2001:0db8:85a3::/48";
         let result = cidr_finder(&input);
-        assert_eq!(result, vec!["2001:db8::/32", "fe80::/10", "::1/128", "::/0", "2001:0db8:85a3::/48"]);
+        assert_eq!(
+            result,
+            vec![
+                "2001:db8::/32",
+                "fe80::/10",
+                "::1/128",
+                "::/0",
+                "2001:0db8:85a3::/48"
+            ]
+        );
     }
 
     #[test]
@@ -813,7 +945,10 @@ Email: john.doe@company.com"#;
     fn test_range_finder_ipv6_comprehensive() {
         let input = "2001:db8::1-2001:db8::10 fe80::1-fe80::ffff ::1-::2";
         let result = range_finder(&input);
-        assert_eq!(result, vec!["2001:db8::1-2001:db8::10", "fe80::1-fe80::ffff", "::1-::2"]);
+        assert_eq!(
+            result,
+            vec!["2001:db8::1-2001:db8::10", "fe80::1-fe80::ffff", "::1-::2"]
+        );
     }
 
     #[test]
@@ -834,12 +969,12 @@ Email: john.doe@company.com"#;
         route add -inet6 2001:db8::/32 gateway fe80::1
         "#;
         let result = ip_finder(&input);
-        
+
         // Verify common IPv6 addresses are extracted from realistic log content
         assert!(result.contains(&"2001:db8::1".to_string()));
         assert!(result.contains(&"2001:db8::2".to_string()));
         assert!(result.contains(&"fe80::1".to_string()));
-        
+
         // Note: http://[::1]:8080/api doesn't extract ::1 due to http:// prefix parsing
         // which is expected behavior for URL contexts
     }


### PR DESCRIPTION
## Summary
- drop the `FORCE_EDITOR` environment variable
- rely solely on TTY detection for launching `$EDITOR`
- adjust debug-mode test accordingly
- fallback to stdin if no editor is found

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68428ea56664832a948dd92c978a51aa