### PR TITLE
Improve editor fallback messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Run without arguments to launch your `$EDITOR` for interactive input. If no edit
 extract
 ```
 
-Enter your text in the editor and save. If using the stdin fallback, end the input with Ctrl-D when finished.
+Enter your text in the editor and save. If using the stdin fallback, end the input with Ctrl-D or EOF on a new line when finished.
 
 ### Command Options
 


### PR DESCRIPTION
## Summary
- log the `EDITOR` variable value and only print editor startup message at debug level
- warn if no editor is found and show instructions for manual input
- clarify stdin fallback instructions in README

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684518aace14832a99a5ecefdacb52dc