### PR TITLE
Bump version to 0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "extract"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extract"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Extract network identifiers from text"
 repository = "https://github.com/bedecarroll/extract"

--- a/src/main.rs
+++ b/src/main.rs
@@ -528,7 +528,7 @@ mod tests {
     #[test]
     fn test_version_subcommand() {
         let mut cmd = Command::cargo_bin("extract").unwrap();
-        cmd.arg("version").assert().success().stdout("0.0.1\n");
+        cmd.arg("version").assert().success().stdout("0.0.2\n");
     }
 
     #[test]
@@ -537,7 +537,7 @@ mod tests {
         cmd.arg("--version")
             .assert()
             .success()
-            .stdout(predicate::str::contains("0.0.1"));
+            .stdout(predicate::str::contains("0.0.2"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- bump crate version to `0.0.2`
- update tests expecting the CLI version output

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68451c8274f0832a888ef1e228cdb350