### PR TITLE
Fix editor selection when VISUAL is set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -525,6 +525,7 @@ fn gather_interactive_input(config: &AppConfig) -> io::Result<String> {
             io::stdin().read_to_string(&mut input)?;
         } else {
             std::env::set_var("EDITOR", ed);
+            std::env::set_var("VISUAL", ed);
             let editor_env = ed.to_string();
             if which(&editor_env).is_err() {
                 warn!("Editor not found. EDITOR={editor_env:?}");


### PR DESCRIPTION
## Summary
- set VISUAL along with EDITOR when using a configured editor

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings -W clippy::pedantic`
- `cargo test`
- `cargo bench --bench performance`

------
https://chatgpt.com/codex/tasks/task_e_684650146430832aa878d9b8135eabd4