### PR TITLE
Add file input args

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ extract
 Enter your text in the editor and save. If using the stdin fallback, end the
 input with Ctrl-D or EOF on a new line when finished.
 
+### File Input
+
+Provide one or more file paths to read input directly from those files:
+
+```bash
+extract network.log
+```
+
 ### Command Options
 
 - `--debug`: Enable debug logging
@@ -243,16 +251,16 @@ standard tools:
 
 ```bash
 # Remove duplicates
-extract < input.txt | sort | uniq
+extract input.txt | sort | uniq
 
 # Filter specific types
-extract < logs.txt | grep "192.168"
+extract logs.txt | grep "192.168"
 
 # Count occurrences
-extract < data.txt | sort | uniq -c | sort -nr
+extract data.txt | sort | uniq -c | sort -nr
 
 # Save results
-extract < incident_report.txt > network_assets.txt
+extract incident_report.txt > network_assets.txt
 ```
 
 ## Development Guidelines

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -9,7 +9,7 @@ echo "Server at 192.168.1.1 connected" | extract
 
 ```bash
 # Process a log file and remove duplicates
-extract < /var/log/firewall.log | sort | uniq
+extract /var/log/firewall.log | sort | uniq
 ```
 
 ```bash
@@ -20,5 +20,5 @@ extract
 
 ```bash
 # Combine with grep to filter for a specific network
-extract < syslog.txt | grep "192.168.1."
+extract syslog.txt | grep "192.168.1."
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ enum ConfigCommands {
     about = "Extract network identifiers from text"
 )]
 struct Cli {
+    /// Files to parse instead of stdin or interactive mode.
+    #[arg(value_name = "FILE")]
+    files: Vec<std::path::PathBuf>,
+
     /// Enable debug logging.
     #[arg(long)]
     debug: bool,
@@ -609,7 +613,13 @@ fn main() {
         return;
     }
 
-    let result = if atty::is(Stream::Stdin) {
+    let result = if !cli.files.is_empty() {
+        cli.files.iter().try_for_each(|path| {
+            std::fs::File::open(path)
+                .map(std::io::BufReader::new)
+                .and_then(|reader| process_lines(reader, &config))
+        })
+    } else if atty::is(Stream::Stdin) {
         gather_interactive_input(&config).and_then(|input| {
             let cursor = io::Cursor::new(input);
             process_lines(cursor, &config)
@@ -771,6 +781,22 @@ mod tests {
             .assert()
             .success()
             .stdout("192.168.1.1\n10.0.0.0/8\n00:11:22:33:44:55\n172.16.1.1-172.16.1.10\n");
+    }
+
+    #[test]
+    fn test_main_reads_from_file() {
+        use std::fs;
+
+        let path = std::env::temp_dir().join("extract_test_input.txt");
+        fs::write(&path, "1.2.3.4 5.6.7.8\n").unwrap();
+
+        let mut cmd = Command::cargo_bin("extract").unwrap();
+        cmd.arg(path.to_str().unwrap())
+            .assert()
+            .success()
+            .stdout("1.2.3.4\n5.6.7.8\n");
+
+        fs::remove_file(path).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse file paths as positional arguments instead of `--file`
- update documentation and examples
- test new file argument behavior

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings -W clippy::pedantic`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68465742594c832a92036a91ca186ac0