### PR TITLE
Add log_level config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ extract
 Enter your text in the editor and save. If using the stdin fallback, end the
 input with Ctrl-D or EOF on a new line when finished.
 
-### Command Options
+-### Command Options
 
-- `--debug`: Enable debug logging
+- `--log-level <level>`: Set logging verbosity (error, warn, info, debug)
 - `--version`: Show version information
 - `version`: Show version (subcommand)
 - `config print`: Show the loaded configuration
@@ -120,13 +120,13 @@ input with Ctrl-D or EOF on a new line when finished.
 `~/.config/extract/config.toml` when `XDG_CONFIG_HOME` is not set. Additional
 files in a sibling `conf.d` directory are loaded in alphabetical order. These
 can override settings or extend the `custom_regexes` list. The configuration
-supports a `debug` flag, an optional `editor` string, and a `custom_regexes`
+supports a `log_level` option, an optional `editor` string, and a `custom_regexes`
 table mapping regex patterns to replacement strings. Replacements can reference
 capture groups using `$1`, `$2`, and so on. If the configured editor cannot be
 found, the program falls back to reading from stdin:
 
 ```toml
-debug = false
+log_level = "warn"
 # editor to launch for interactive mode (empty string disables the editor)
 editor = "nano"
 # editor = ""

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -7,10 +7,10 @@
 ## Custom Configuration
 
 Create `~/.config/extract/config.toml` to tweak behaviour. You can supply your
-own regex patterns and enable debug logging:
+own regex patterns and adjust logging level:
 
 ```toml
-debug = true
+log_level = "debug"
 custom_regexes = { serial = "SERIAL\\d+" }
 ```
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,6 +1,6 @@
 # Example configuration for extract
-# Set debug logging level
-debug = false
+# Set logging level (error, warn, info, debug)
+log_level = "warn"
 # Specify an editor, or set to empty to disable editor usage.
 # If the command is not found, stdin will be used instead.
 editor = "nano"


### PR DESCRIPTION
## Summary
- add `log_level` setting to CLI and configuration
- default logging level to warn and update example config
- document new option in README and docs
- adjust tests for log level changes

## Testing
- `cargo clippy -- -D warnings -W clippy::pedantic`
- `cargo test`
- `cargo bench --bench performance`

------
https://chatgpt.com/codex/tasks/task_e_684658777764832abe79738a01d86361