### PR TITLE
Prepare for 0.1.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "extract"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extract"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 description = "Extract network identifiers from text"
 repository = "https://github.com/bedecarroll/extract"

--- a/src/main.rs
+++ b/src/main.rs
@@ -561,7 +561,7 @@ mod tests {
     #[test]
     fn test_version_subcommand() {
         let mut cmd = Command::cargo_bin("extract").unwrap();
-        cmd.arg("version").assert().success().stdout("0.0.2\n");
+        cmd.arg("version").assert().success().stdout("0.1.0\n");
     }
 
     #[test]
@@ -570,7 +570,7 @@ mod tests {
         cmd.arg("--version")
             .assert()
             .success()
-            .stdout(predicate::str::contains("0.0.2"));
+            .stdout(predicate::str::contains("0.1.0"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- bump version from 0.0.2 to 0.1.0
- update version expectations in version tests

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings -W clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6845c2bd7dd4832a99096def79f4a03b