### PR TITLE
Improve logging clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ unstructured text blobs.
 - **IP Ranges**: Range notation like `192.168.1.1-192.168.1.10`
 - **Smart Parsing**: Handles quotes, brackets, and various delimiters
 - **Complex Text**: Works with logs, support tickets, and mixed content
-- **Debug Logging**: Optional verbose output for troubleshooting
+- **Configurable Logging**: Info logs list matches.  
+  Debug logs show tokenization steps.
 - **Streaming Processing**: Lines are processed one by one for low memory usage
 
 ## Installation

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -14,6 +14,10 @@ log_level = "debug"
 custom_regexes = { serial = "SERIAL\\d+" }
 ```
 
+`log_level` controls verbosity. At `info` level, every match is reported. Use
+`debug` for detailed processing steps showing how tokens are parsed and why
+rules may not match.
+
 ## Benchmarking
 
 Run Criterion benchmarks to gauge performance over time:


### PR DESCRIPTION
## Summary
- make info level log matched tokens
- add verbose debug messages to show token processing
- document logging levels in README and docs

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings -W clippy::pedantic`
- `cargo test`
- `markdownlint-cli2 "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_68467beb8730832a980871751dcd2d59