### PR TITLE
Fix capture group indexing in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ editor = "nano"
 # "(ocid1\\S+)" = "$0"
 
 # Extract IP:PORT combinations (built-in extractors remove ports)
-# "(\\d+\\.\\d+\\.\\d+\\.\\d+:\\d+)" = "$1"
+# "\\d+\\.\\d+\\.\\d+\\.\\d+:\\d+" = "$0"
 
 # Extract IPv6 with ports in custom format
 # "\\[([0-9a-fA-F:]+)\\]:(\\d+)" = "$1:$2"
@@ -164,6 +164,7 @@ Custom regexes are applied **after** the built-in extractors, which means:
 1. **Built-in extractors** run first and apply automatic port removal for IP addresses
 2. **Custom regexes** run on the original input text and can capture any
    patterns you define
+   (regexes match across whitespace unless you add anchors like `\b`, `^`, or `$`)
 
 This allows you to use custom regexes to extract patterns that the built-in
 extractors might modify. For example:

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -11,8 +11,12 @@ own regex patterns and adjust logging level:
 
 ```toml
 log_level = "debug"
-custom_regexes = { serial = "SERIAL\\d+" }
+[custom_regexes]
+"SERIAL\\d+" = "$0"
 ```
+
+These patterns match anywhere on a line. Add word boundaries or anchors to
+prevent capturing text across multiple tokens.
 
 `log_level` controls verbosity. At `info` level, every match is reported. Use
 `debug` for detailed processing steps showing how tokens are parsed and why

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -13,7 +13,7 @@ editor = "nano"
 "(ocid1\\S+)" = "$0"
 
 # Extract IP:PORT combinations (built-in extractors remove ports)
-"(\\d+\\.\\d+\\.\\d+\\.\\d+:\\d+)" = "$1"
+"\\d+\\.\\d+\\.\\d+\\.\\d+:\\d+" = "$0"
 
 # Extract IPv6 with ports in brackets
 "\\[([0-9a-fA-F:]+)\\]:(\\d+)" = "$1:$2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2013,8 +2013,8 @@ Email: john.doe@company.com"#;
     fn test_custom_regex_preserves_ports() {
         // Test that custom regexes can extract IP:PORT while built-in extractors remove ports
         let rules = vec![CustomRule {
-            regex: Regex::new(r"(\d+\.\d+\.\d+\.\d+:\d+)").unwrap(),
-            replace: "$1".to_string(),
+            regex: Regex::new(r"\d+\.\d+\.\d+\.\d+:\d+").unwrap(),
+            replace: "$0".to_string(),
         }];
 
         let input = "server at 192.168.1.1:8080 and 10.0.0.1:443";


### PR DESCRIPTION
## Summary
- correct regex capture group examples for IP:PORT
- update test to use `$0` instead of `$1`
- clarify regex termination in docs

## Testing
- `npx markdownlint-cli2 "**/*.md"`
- `cargo fmt --all`
- `cargo clippy -- -D warnings -W clippy::pedantic`
- `cargo test`
- `cargo bench --bench performance`


------
https://chatgpt.com/codex/tasks/task_e_6846ed0b83cc832aaa28d7e5b8275866