### PR TITLE
Add --regex CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ extract network.log
 ### Command Options
 
 - `--log-level <level>`: Set logging verbosity (error, warn, info, debug)
+- `--regex <pattern>`: Apply a one-off regular expression (can be repeated)
 - `--version`: Show version information
 - `version`: Show version (subcommand)
 - `config print`: Show the loaded configuration

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -7,7 +7,8 @@
 ## Custom Configuration
 
 Create `~/.config/extract/config.toml` to tweak behaviour. You can supply your
-own regex patterns and adjust logging level:
+own regex patterns and adjust logging level. For quick one-off patterns, use
+the `--regex` flag on the command line and repeat it for multiple patterns:
 
 ```toml
 log_level = "debug"


### PR DESCRIPTION
## Summary
- add `--regex` option to apply custom regex patterns from the command line
- document the flag in the README and advanced usage guide
- test single and repeated `--regex` usage

## Testing
- `cargo clippy -- -D warnings -W clippy::pedantic`
- `cargo test`
- `cargo bench --bench performance`
- `markdownlint-cli2 "**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_684726d6ec18832a827f048d887beb21