### PR TITLE
Fix editor invocation with piped output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "log",
  "predicates",
  "regex",
+ "tempfile",
  "toml",
  "which 8.0.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ edit = "0.1.5"
 atty = "0.2"
 toml = "0.8"
 which = "8"
+tempfile = "3"
 
 [dev-dependencies]
 assert_cmd = "2.0"


### PR DESCRIPTION
## Summary
- open the editor through `/dev/tty` when stdout isn't a TTY
- use new `edit_with_tty` helper for interactive input
- add `tempfile` dependency for temporary files

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings -W clippy::pedantic`
- `cargo test`
- `npx markdownlint-cli2 "**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_6851ba110ce8832a8be2d38c7db80edd